### PR TITLE
Refactor: cut requirements file and remove references from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,15 +407,15 @@ python-health-monitor --help
 
 ### Production Deployment
 ```bash
-# Install production dependencies
-pip install -r requirements.txt
+# Install the project and its production dependencies
+pip install .
 
 # Set up configuration
 cp config/config.yaml config/production.yaml
 # Edit production.yaml with your endpoints
 
 # Run with production config
-python monitor.py --config config/production.yaml
+python -m python_health_monitor.monitor --config config/production.yaml
 ```
 
 ### Systemd Service (Linux)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-requests
-boto3
-pytest
-PyYAML
-awscli-local
-localstack-client


### PR DESCRIPTION
In the modularized and packaged version of health-monitor remove the requirements file since it is deprecated in favor of the `pyproject.toml` file, and remove references to `requirements.txt` from the readme file